### PR TITLE
Upgrade to Apache Kafka 3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <mockito.version>5.7.0</mockito.version>
         <assertj-core.version>3.24.2</assertj-core.version>
         <mockito.version>5.7.0</mockito.version>
-        <kafka.version>3.7.0</kafka.version>
+        <kafka.version>3.9.0</kafka.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <kroxylicious-testing-junit5-extension.version>0.10.0</kroxylicious-testing-junit5-extension.version>
         <micrometer-core.version>1.12.2</micrometer-core.version>

--- a/src/main/java/io/github/andreatp/kroxylicious/wasm/util/SampleWasmFilterTransformer.java
+++ b/src/main/java/io/github/andreatp/kroxylicious/wasm/util/SampleWasmFilterTransformer.java
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 import io.github.andreatp.kroxylicious.wasm.config.SampleFilterConfig;
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.record.AbstractRecords;
@@ -125,7 +126,7 @@ public class SampleWasmFilterTransformer {
      * functionality in io.kroxylicious.proxy.internal, but we aren't supposed to import from there.
      */
     private static MemoryRecordsBuilder createMemoryRecordsBuilder(ByteBufferOutputStream stream, RecordBatch firstBatch) {
-        return new MemoryRecordsBuilder(stream, firstBatch.magic(), firstBatch.compressionType(), firstBatch.timestampType(), firstBatch.baseOffset(),
+        return new MemoryRecordsBuilder(stream, firstBatch.magic(), Compression.of(firstBatch.compressionType()).build(), firstBatch.timestampType(), firstBatch.baseOffset(),
                 firstBatch.maxTimestamp(), firstBatch.producerId(), firstBatch.producerEpoch(), firstBatch.baseSequence(), firstBatch.isTransactional(),
                 firstBatch.isControlBatch(), firstBatch.partitionLeaderEpoch(), stream.remaining());
     }

--- a/src/test/java/io/github/andreatp/kroxylicious/wasm/SampleFetchResponseFilterTest.java
+++ b/src/test/java/io/github/andreatp/kroxylicious/wasm/SampleFetchResponseFilterTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import io.github.andreatp.kroxylicious.wasm.config.SampleFilterConfig;
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.message.ApiMessageType;
@@ -153,7 +154,7 @@ class SampleFetchResponseFilterTest {
         // Build stream
         var stream = new ByteBufferOutputStream(ByteBuffer.wrap(transformValue.getBytes(StandardCharsets.UTF_8)));
         // Build records from stream
-        var recordsBuilder = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE, TimestampType.CREATE_TIME, 0,
+        var recordsBuilder = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, Compression.NONE, TimestampType.CREATE_TIME, 0,
                 RecordBatch.NO_TIMESTAMP, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, false, false,
                 RecordBatch.NO_PARTITION_LEADER_EPOCH, stream.remaining());
         // Create record Headers

--- a/src/test/java/io/github/andreatp/kroxylicious/wasm/SampleProduceRequestFilterTest.java
+++ b/src/test/java/io/github/andreatp/kroxylicious/wasm/SampleProduceRequestFilterTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import io.github.andreatp.kroxylicious.wasm.config.SampleFilterConfig;
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.message.ApiMessageType;
@@ -146,7 +147,7 @@ class SampleProduceRequestFilterTest {
         // Build stream
         var stream = new ByteBufferOutputStream(ByteBuffer.wrap(transformValue.getBytes(StandardCharsets.UTF_8)));
         // Build records from stream
-        var recordsBuilder = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE, TimestampType.CREATE_TIME, 0,
+        var recordsBuilder = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, Compression.NONE, TimestampType.CREATE_TIME, 0,
                 RecordBatch.NO_TIMESTAMP, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, false, false,
                 RecordBatch.NO_PARTITION_LEADER_EPOCH, stream.remaining());
         // Create record Headers


### PR DESCRIPTION
Upgrade to Apache Kafka 3.9.   There are some API differences in the Kafka APIs, hence the need for a couple of code changes (around compression).